### PR TITLE
Fix namespacing in README for \App\App\Nova

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ class NovaServiceProvider extends NovaApplicationServiceProvider
                     TopLevelResource::make([
                         'label' => 'Resources',
                         'resources' => [
-                            \App\App\Nova\User::class
+                            \App\Nova\User::class
                         ]
                     ]),
                 ]


### PR DESCRIPTION
In the documentation first example line `\App\App\Nova\User::class` was nested too deeply, it's rather found at `\App\Nova\User::class`